### PR TITLE
Address worked example docs and centralized seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build/
 
 # --- Site ---
 site/
+
+# --- Other ---
+ignored_from_git

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This tool evaluates net load forecasting models aiming to make new net load fore
 
 It also allows users to add datasets, models, and modify hyperparameters. Researchers claiming a new or superior model can compare their model with existing ones on public datasets. The target audience includes researchers in academia or industry focused on evaluating and optimizing net load forecasting models.
 
+For worked guidance, see the documentation on [how to add a model](https://mssamhan31.github.io/PyNNLF/add_model/) and [how to modify model hyperparameters](https://mssamhan31.github.io/PyNNLF/modify_hyper/).
+
 A visual illustration of the tool workflow is shown below.
 
 ![Home Illustration](./docs/img/home_illustration.png)
@@ -14,8 +16,8 @@ A visual illustration of the tool workflow is shown below.
 2. **Model Specification**: model and hyperparameters defined in `example_project/specs/experiment.yaml`.
 
 # Output
-1. `a1_experiment_result.csv` - Contains accuracy (cross-validated test n-RMSE), stability (accuracy standard deviation), and training time.
-2. `a2_hyperparameter.csv` - Lists the hyperparameters used for each model.
+1. `a1_experiment_result.csv` - Contains accuracy (cross-validated test n-RMSE), stability (accuracy standard deviation), training time, and the run seed.
+2. `a2_hyperparameter.csv` - Lists the effective hyperparameters used for each model.
 3. `a3_cross_validation_result.csv` - Detailed results for each cross-validation split.
 4. `E00001_cv1_plots/` - Optional plot folder for the first CV fold when plot generation is enabled.
 5. `cv_test/` and `cv_train/` - Folders containing time series of observations, forecasts, and residuals for each cross-validation split.

--- a/docs/add_model.md
+++ b/docs/add_model.md
@@ -23,6 +23,8 @@ Create a new `.py` file under your workspace `models` folder. The file name must
 
 You can start from the template file `models/mXX_template.py` in your workspace.
 
+If the model uses randomness, use a standard seed-like hyperparameter key such as `seed`, `random_seed`, or `random_state`. PyNNLF can override these keys from the central `reproducibility.seed` value in `specs/pynnlf_config.yaml` so experiments remain comparable.
+
 ### 2. Add hyperparameters for the new model
 
 Add a new top-level key in `example_project/models/hyperparameters.yaml`. The key must match the full model file stem, for example `m19_my_model`.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -420,7 +420,7 @@ Args:
 
 - `cross_val_result_df`: a3 cross-validation dataframe.
 
-- `hyperparameter`: hyperparameter dict.
+- `hyperparameter`: effective hyperparameter dict used for the run.
 
 Returns:
 
@@ -616,6 +616,10 @@ Args:
 - `plot_enabled`: whether to write plot PNGs for the first CV fold.
 
 - `plot_style`: plot settings.
+
+- `run_seed`: optional central run seed recorded in `a1`.
+
+- `seed_keys_overridden`: optional seed-like hyperparameter keys overridden to `run_seed`.
 
 Returns:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -38,17 +38,17 @@ The tool generates the following outputs.
 | `E00001_cv_train/`          | Folder | Time series of observation, forecast, and residual for each cross-validation split |
 | `E00001_cv1_plots/`         | Folder | Optional folder with plots for the first cross-validation fold when plot generation is enabled |
 | `E00001_models/`            | Folder | Saved models used or generated during the experiment      |
-| `E00001_a1_experiment_result.csv` | File   | Accuracy (cross-validated test n-RMSE), stability, and training time |
-| `E00001_a2_hyperparameter.csv`    | File   | Hyperparameters used for each model                        |
+| `E00001_a1_experiment_result.csv` | File   | Accuracy (cross-validated test n-RMSE), stability, training time, and run seed |
+| `E00001_a2_hyperparameter.csv`    | File   | Effective hyperparameters used for each model              |
 | `E00001_a3_cross_validation_result.csv` | File | Detailed results for each cross-validation split          |
 
-The file `a1_experiment_result.csv` summarises the results, including the cross validated nRMSE & its standard deviation.
+The file `a1_experiment_result.csv` summarises the results, including the cross validated nRMSE, its standard deviation, `run_seed`, and `seed_keys_overridden`.
 
 To aggregate multiple experiments into one recap, run `recap_experiments` to write a workspace-level `a1_experiment_result.csv` that includes the `experiment_folder` column.
 
-| experiment_no | exp_date   | dataset_no | dataset | dataset_freq_min | dataset_length_week | forecast_horizon_min | train_pct | test_pct | model_no | hyperparameter_no | model_name   | hyperparameter       | runtime_ms  | train_RMSE | train_RMSE_stddev | test_RMSE | test_RMSE_stddev | train_nRMSE | train_nRMSE_stddev | test_nRMSE | test_nRMSE_stddev |
-|---------------|-----------|------------|--------|----------------|-------------------|--------------------|-----------|----------|----------|-----------------|-------------|--------------------|------------|------------|-----------------|-----------|-----------------|------------|------------------|------------|------------------|
-| E00001        | 15/09/2025 | ds0       | test   | 30             | 10                | 30                 | 0.9       | 0.1      | m6       | hp1             | m6_lr_hp1   | num_features: 50   | 201.769185 | 17.33      | 0.206421         | 17.7066   | 1.82726         | 2.98206    | 0.03552          | 3.04686    | 0.31443          |
+| experiment_no | exp_date   | dataset_no | dataset | dataset_freq_min | dataset_length_week | forecast_horizon_min | train_pct | test_pct | model_no | hyperparameter_no | model_name   | hyperparameter       | run_seed | seed_keys_overridden | runtime_ms  | train_RMSE | train_RMSE_stddev | test_RMSE | test_RMSE_stddev | train_nRMSE | train_nRMSE_stddev | test_nRMSE | test_nRMSE_stddev |
+|---------------|-----------|------------|--------|----------------|-------------------|--------------------|-----------|----------|----------|-----------------|-------------|--------------------|----------|----------------------|------------|------------|-----------------|-----------|-----------------|------------|------------------|------------|------------------|
+| E00001        | 15/09/2025 | ds0       | test   | 30             | 10                | 30                 | 0.9       | 0.1      | m6       | hp1             | m6_lr_hp1   | num_features: 50   | 99       |                      | 201.769185 | 17.33      | 0.206421         | 17.7066   | 1.82726         | 2.98206    | 0.03552          | 3.04686    | 0.31443          |
 
 The file `a3_cross_validation_result.csv` provides the detailed cross-validation (CV) results, from CV1 to CV10.
 # Experiment Metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ This tool evaluates net load forecasting models reliably and reproducibly. It in
 
 It also allows users to add datasets, models, and modify hyperparameters. Researchers claiming a new or superior model can compare their model with existing ones on public datasets. The target audience includes researchers in academia or industry focused on evaluating and optimizing net load forecasting models.
 
+For worked guidance, see [How to add a model](add_model.md) and [How to modify model hyperparameter](modify_hyper.md).
+
 A visual illustration of the tool workflow is shown below.
 ![Home Illustration](img/home_illustration.png)
 
@@ -16,8 +18,8 @@ A visual illustration of the tool workflow is shown below.
 2. **Model Specification**: model and hyperparameters defined in `example_project/specs/experiment.yaml`.
 
 # Output
-1. `a1_experiment_result.csv` - Contains accuracy (cross-validated test n-RMSE), stability (accuracy stddev), and training time.
-2. `a2_hyperparameter.csv` - Lists hyperparameters used for each model.
+1. `a1_experiment_result.csv` - Contains accuracy (cross-validated test n-RMSE), stability (accuracy stddev), training time, and the run seed.
+2. `a2_hyperparameter.csv` - Lists effective hyperparameters used for each model.
 3. `a3_cross_validation_result.csv` - Detailed results for each cross-validation split.
 4. `E00001_cv1_plots/` - Optional plot folder for the first CV fold when plot generation is enabled.
 5. `cv_test/` and `cv_train/` - Folders containing time series of observation, forecast, and residuals for each cross-validation split.

--- a/docs/modify_hyper.md
+++ b/docs/modify_hyper.md
@@ -4,6 +4,8 @@ All hyperparameter values are stored separately from the model code in `models/h
 
 This design avoids hard-coded values and provides a central place to manage model settings.
 
+The workspace config also includes `reproducibility.seed` in `specs/pynnlf_config.yaml`. When this value is set, PyNNLF seeds common random number generators and overrides seed-like hyperparameter keys such as `seed`, `xgb_seed`, `random_seed`, and `random_state` at runtime. The experiment summary records the central seed in `a1_experiment_result.csv`, and `a2_hyperparameter.csv` records the effective hyperparameters used for the run.
+
 ## Format
 
 PyNNLF expects a YAML mapping:

--- a/example_project/specs/pynnlf_config.yaml
+++ b/example_project/specs/pynnlf_config.yaml
@@ -3,6 +3,9 @@ paths:
   output_dir: experiment_result
   hyperparameters_path: models/hyperparameters.yaml
 
+reproducibility:
+  seed: 99
+
 dataset_download:
   base_url: "https://raw.githubusercontent.com/mssamhan31/PyNNLF/main/data/"
 

--- a/src/pynnlf/engine.py
+++ b/src/pynnlf/engine.py
@@ -10,7 +10,9 @@ import dill # for saving trained model
 import importlib.util
 from pathlib import Path   
 import re
- 
+
+from .reproducibility import apply_reproducibility_config
+
 
 
 # # FOLDER PREPARATION
@@ -627,6 +629,8 @@ def run_model(
     n_block,
     plot_enabled,
     plot_style,
+    run_seed=None,
+    seed_keys_overridden=None,
 ):
     """
     Run CV loop, train model, forecast, export outputs.
@@ -649,6 +653,8 @@ def run_model(
         n_block (int): k + 1
         plot_enabled (bool): plot on/off
         plot_style (dict): colors + font
+        run_seed (int | None): central run seed from config
+        seed_keys_overridden (list[str] | None): seed-like hp keys forced to run_seed
 
     Returns:
         None
@@ -812,6 +818,8 @@ def run_model(
         "hyperparameter_no": hyperparameter_no,
         "model_name": model_name + '_' + hyperparameter_no,
         "hyperparamter": ', '.join(f"{k}: {v}" for k, v in hyperparameter.items()),  
+        "run_seed": run_seed if run_seed is not None else "",
+        "seed_keys_overridden": ", ".join(seed_keys_overridden or []),
         "runtime_ms": cross_val_result_df.loc['mean', 'runtime_ms'],
         "train_RMSE": cross_val_result_df.loc['mean', 'train_RMSE'],
         "train_RMSE_stddev": cross_val_result_df.loc['stddev', 'train_RMSE'],
@@ -877,6 +885,10 @@ def run_experiment_engine(
     """
     dataset_path = Path(dataset_path)
     dataset_file = dataset_path.name
+    hyperparameter, run_seed, seed_keys_overridden = apply_reproducibility_config(
+        config,
+        hyperparameter,
+    )
 
     # CV config
     k = int(config["cv"]["k"])
@@ -928,6 +940,8 @@ def run_experiment_engine(
         n_block=n_block,
         plot_enabled=bool(config["plot"]["enabled"]),
         plot_style=config["plot"],
+        run_seed=run_seed,
+        seed_keys_overridden=seed_keys_overridden,
     )
 
 # # PERFORMANCE COMPUTATION

--- a/src/pynnlf/reproducibility.py
+++ b/src/pynnlf/reproducibility.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import os
+import random
+
+
+SEED_KEYS = ("seed", "xgb_seed", "random_seed", "random_state")
+
+
+def get_run_seed(config: dict[str, Any]) -> int | None:
+    """Return the configured run seed, if one is configured."""
+    reproducibility = config.get("reproducibility", {}) or {}
+    seed = reproducibility.get("seed")
+    if seed is None or seed == "":
+        return None
+    return int(seed)
+
+
+def seed_everything(seed: int | None) -> None:
+    """Seed common Python ML RNGs when they are available."""
+    if seed is None:
+        return
+
+    seed = int(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        np.random.seed(seed)
+
+    try:
+        import torch
+    except ImportError:
+        return
+
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+    if hasattr(torch.backends, "cudnn"):
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    if hasattr(torch, "use_deterministic_algorithms"):
+        torch.use_deterministic_algorithms(True, warn_only=True)
+
+
+def apply_reproducibility_config(
+    config: dict[str, Any],
+    hyperparameter: dict[str, Any],
+) -> tuple[dict[str, Any], int | None, list[str]]:
+    """
+    Apply run-level reproducibility settings to a copy of hyperparameters.
+
+    Returns the effective hyperparameters, the run seed, and seed-like keys
+    that were overridden to the run seed.
+    """
+    run_seed = get_run_seed(config)
+    effective_hyperparameter = deepcopy(hyperparameter)
+    overridden_keys: list[str] = []
+
+    if run_seed is None:
+        return effective_hyperparameter, None, overridden_keys
+
+    seed_everything(run_seed)
+    for key in SEED_KEYS:
+        if key in effective_hyperparameter:
+            effective_hyperparameter[key] = run_seed
+            overridden_keys.append(key)
+
+    return effective_hyperparameter, run_seed, overridden_keys

--- a/src/pynnlf/scaffold/specs/pynnlf_config.yaml
+++ b/src/pynnlf/scaffold/specs/pynnlf_config.yaml
@@ -3,6 +3,9 @@ paths:
   output_dir: experiment_result
   hyperparameters_path: models/hyperparameters.yaml
 
+reproducibility:
+  seed: 99
+
 dataset_download:
   base_url: "https://raw.githubusercontent.com/mssamhan31/PyNNLF/main/data/"
 


### PR DESCRIPTION
## Summary
- Add README/docs links for adding models and modifying hyperparameters.
- Centralize experiment seeding through `reproducibility.seed` in YAML config.
- Record seed details in the existing CSV outputs instead of adding a metadata sidecar file.

Closes #21
Closes #22