### PR TITLE
Add polished PyNNLF website homepage

### DIFF
--- a/docs/assets/css/website.css
+++ b/docs/assets/css/website.css
@@ -1,0 +1,286 @@
+:root {
+  --pynnlf-ink: #18212a;
+  --pynnlf-muted: #5d6770;
+  --pynnlf-line: #dfe6eb;
+  --pynnlf-soft: #f6f8f9;
+  --pynnlf-teal: #007a78;
+  --pynnlf-teal-dark: #005f5e;
+  --pynnlf-rust: #bd573f;
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3 {
+  letter-spacing: 0;
+}
+
+.md-typeset .pynnlf-landing {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.md-typeset .pynnlf-hero {
+  min-height: 68vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 4.5rem 0 3.5rem;
+  border-bottom: 1px solid var(--pynnlf-line);
+}
+
+.pynnlf-eyebrow {
+  margin: 0 0 0.9rem;
+  color: var(--pynnlf-teal);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.md-typeset .pynnlf-hero h1 {
+  max-width: 920px;
+  margin: 0;
+  color: var(--pynnlf-ink);
+  font-size: clamp(2.5rem, 6vw, 5.6rem);
+  font-weight: 850;
+  line-height: 0.98;
+}
+
+.pynnlf-hero__lead {
+  max-width: 780px;
+  margin: 1.45rem 0 1.7rem;
+  color: var(--pynnlf-muted);
+  font-size: clamp(1.05rem, 2vw, 1.28rem);
+  line-height: 1.65;
+}
+
+.pynnlf-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.pynnlf-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.45rem;
+  padding: 0.62rem 1rem;
+  border: 1px solid var(--pynnlf-line);
+  border-radius: 4px;
+  background: #fff;
+  color: var(--pynnlf-ink);
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.pynnlf-button:hover {
+  border-color: var(--pynnlf-teal);
+  color: var(--pynnlf-teal-dark);
+}
+
+.pynnlf-button--primary {
+  border-color: var(--pynnlf-teal);
+  background: var(--pynnlf-teal);
+  color: #fff;
+}
+
+.pynnlf-button--primary:hover {
+  background: var(--pynnlf-teal-dark);
+  color: #fff;
+}
+
+.pynnlf-section {
+  padding: 4rem 0;
+  border-bottom: 1px solid var(--pynnlf-line);
+}
+
+.pynnlf-section__intro {
+  max-width: 840px;
+}
+
+.md-typeset .pynnlf-section h2 {
+  max-width: 900px;
+  margin: 0 0 1rem;
+  color: var(--pynnlf-ink);
+  font-size: clamp(1.85rem, 4vw, 3.35rem);
+  line-height: 1.05;
+  font-weight: 820;
+}
+
+.pynnlf-section p {
+  color: var(--pynnlf-muted);
+  font-size: 1.02rem;
+  line-height: 1.68;
+}
+
+.pynnlf-problem {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+.pynnlf-quote-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.pynnlf-quote-stack figure {
+  margin: 0;
+  padding: 1.1rem 1.15rem;
+  border-left: 4px solid var(--pynnlf-rust);
+  background: var(--pynnlf-soft);
+}
+
+.pynnlf-quote-stack blockquote {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  color: var(--pynnlf-ink);
+  font-size: 1.02rem;
+  line-height: 1.55;
+}
+
+.pynnlf-quote-stack figcaption {
+  margin-top: 0.7rem;
+  color: var(--pynnlf-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.pynnlf-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.pynnlf-stat-grid div {
+  padding-top: 0.75rem;
+  border-top: 3px solid var(--pynnlf-teal);
+}
+
+.pynnlf-stat-grid strong {
+  display: block;
+  color: var(--pynnlf-rust);
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1;
+}
+
+.pynnlf-stat-grid span {
+  display: block;
+  margin-top: 0.6rem;
+  color: var(--pynnlf-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.pynnlf-solution,
+.pynnlf-install {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(300px, 1.05fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+.pynnlf-workflow {
+  display: grid;
+  gap: 0.8rem;
+  counter-reset: workflow;
+}
+
+.pynnlf-workflow span {
+  counter-increment: workflow;
+  display: grid;
+  grid-template-columns: 2.2rem 1fr;
+  gap: 0.8rem;
+  align-items: center;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--pynnlf-line);
+  color: var(--pynnlf-ink);
+  font-weight: 800;
+}
+
+.pynnlf-workflow span::before {
+  content: counter(workflow);
+  display: grid;
+  width: 2.2rem;
+  height: 2.2rem;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--pynnlf-teal);
+  color: #fff;
+  font-size: 0.8rem;
+}
+
+.pynnlf-capability-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.6rem;
+}
+
+.pynnlf-capability-grid article {
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--pynnlf-line);
+}
+
+.md-typeset .pynnlf-capability-grid h3 {
+  margin: 0 0 0.5rem;
+  color: var(--pynnlf-ink);
+  font-size: 1rem;
+}
+
+.pynnlf-capability-grid p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.pynnlf-code-pair {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.pynnlf-code-pair pre {
+  margin: 0;
+  border-radius: 4px;
+}
+
+.pynnlf-references {
+  padding: 1.5rem 0 3rem;
+}
+
+.pynnlf-references p {
+  margin: 0.45rem 0;
+  color: var(--pynnlf-muted);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 1020px) {
+  .pynnlf-stat-grid,
+  .pynnlf-capability-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .md-typeset .pynnlf-hero {
+    min-height: 58vh;
+    padding-top: 3rem;
+  }
+
+  .pynnlf-problem,
+  .pynnlf-solution,
+  .pynnlf-install {
+    grid-template-columns: 1fr;
+    gap: 1.6rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .pynnlf-stat-grid,
+  .pynnlf-capability-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/assets/css/website.css
+++ b/docs/assets/css/website.css
@@ -54,6 +54,14 @@
   line-height: 1.65;
 }
 
+.pynnlf-definition {
+  max-width: 780px;
+  margin: -0.55rem 0 1.7rem;
+  color: var(--pynnlf-muted);
+  font-size: clamp(1.05rem, 2vw, 1.28rem);
+  line-height: 1.65;
+}
+
 .pynnlf-actions {
   display: flex;
   flex-wrap: wrap;
@@ -87,6 +95,20 @@
 
 .pynnlf-button--primary:hover {
   background: var(--pynnlf-teal-dark);
+  color: #fff;
+}
+
+.md-typeset .pynnlf-button--install,
+.md-typeset .pynnlf-button--install:visited {
+  border-color: #1f5fbf;
+  background: #1f5fbf;
+  color: #fff;
+}
+
+.md-typeset .pynnlf-button--install:hover,
+.md-typeset .pynnlf-button--install:focus {
+  border-color: #164a99;
+  background: #164a99;
   color: #fff;
 }
 
@@ -126,6 +148,13 @@
   gap: 1rem;
 }
 
+.pynnlf-quote-lead {
+  margin: 0;
+  color: var(--pynnlf-ink);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
 .pynnlf-quote-stack figure {
   margin: 0;
   padding: 1.1rem 1.15rem;
@@ -147,6 +176,10 @@
   color: var(--pynnlf-muted);
   font-size: 0.76rem;
   font-weight: 700;
+}
+
+.pynnlf-quote-stack figcaption a {
+  color: var(--pynnlf-muted);
 }
 
 .pynnlf-stat-grid {
@@ -255,6 +288,19 @@
   color: var(--pynnlf-muted);
   font-size: 0.72rem;
   line-height: 1.45;
+}
+
+.pynnlf-disclosure {
+  padding: 0 0 3rem;
+}
+
+.pynnlf-disclosure p {
+  margin: 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--pynnlf-line);
+  color: var(--pynnlf-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
 }
 
 @media (max-width: 1020px) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,35 +1,129 @@
-# Welcome to PyNNLF
-PyNNLF (Python for Network Net Load Forecast) is a tool to evaluate net load forecasting model performance in a reliable and reproducible way.
+---
+hide:
+  - navigation
+  - toc
+---
 
-You can access the [GitHub repository here](https://github.com/mssamhan31/PyNNLF).
+<section class="pynnlf-landing">
+  <header class="pynnlf-hero">
+    <p class="pynnlf-eyebrow">PyNNLF</p>
+    <h1>Reliable net load forecasting evaluation, not just another new model.</h1>
+    <p class="pynnlf-hero__lead">
+      PyNNLF is an open-source Python tool for comparing net load forecasting models with public datasets, simple benchmarks, cross-validation, and reproducible experiment outputs.
+    </p>
+    <div class="pynnlf-actions">
+      <a class="pynnlf-button pynnlf-button--primary" href="getting_started/">Install PyNNLF</a>
+      <a class="pynnlf-button" href="examples/">Read the docs</a>
+      <a class="pynnlf-button" href="https://github.com/mssamhan31/PyNNLF">GitHub</a>
+    </div>
+  </header>
 
-# Objective
-This tool evaluates net load forecasting models reliably and reproducibly. It includes a library of public net load datasets and common forecasting models, including simple benchmark models. Users define the forecast problem and model specification in a YAML spec and run experiments through the Python package.
+  <section class="pynnlf-section pynnlf-problem">
+    <div class="pynnlf-section__intro">
+      <p class="pynnlf-eyebrow">The research issue</p>
+      <h2>Many papers claim superior forecasting accuracy. Fewer make the comparison easy to trust.</h2>
+      <p>
+        Since 2016, more than 102 academic papers have been published on net load forecasting. At least 84 introduced a novel method. However, many papers did not use simple benchmark models, relied on private datasets, or did not publicly share implementation code.
+      </p>
+    </div>
 
-It also allows users to add datasets, models, and modify hyperparameters. Researchers claiming a new or superior model can compare their model with existing ones on public datasets. The target audience includes researchers in academia or industry focused on evaluating and optimizing net load forecasting models.
+    <div class="pynnlf-quote-stack">
+      <figure>
+        <blockquote>&ldquo;&hellip; and it is concluded that the proposed method has higher prediction accuracy and better prediction effect &hellip;&rdquo;</blockquote>
+        <figcaption>[1] Cao et al., 2023</figcaption>
+      </figure>
+      <figure>
+        <blockquote>&ldquo;Comparative tests utilizing real-world data verify the superiority of the proposed method over other state-of-the-art net load forecasting algorithms.&rdquo;</blockquote>
+        <figcaption>[2] Hu et al., 2024</figcaption>
+      </figure>
+      <figure>
+        <blockquote>&ldquo;More-over, the performance of the BDLSTM model also dominates when compared with the best of the state-of-the-art methods, &hellip;&rdquo;</blockquote>
+        <figcaption>[3] Sun et al., 2020</figcaption>
+      </figure>
+    </div>
+  </section>
 
-For worked guidance, see [How to add a model](add_model.md) and [How to modify model hyperparameter](modify_hyper.md).
+  <section class="pynnlf-section">
+    <div class="pynnlf-stat-grid" aria-label="Literature review summary facts">
+      <div>
+        <strong>102+</strong>
+        <span>net load forecasting papers since 2016</span>
+      </div>
+      <div>
+        <strong>84</strong>
+        <span>introduced a novel method</span>
+      </div>
+      <div>
+        <strong>75%</strong>
+        <span>did not compare with naive or seasonal naive benchmarks</span>
+      </div>
+      <div>
+        <strong>58%</strong>
+        <span>did not use a publicly available dataset</span>
+      </div>
+      <div>
+        <strong>94%+</strong>
+        <span>did not make their code publicly available</span>
+      </div>
+    </div>
+  </section>
 
-A visual illustration of the tool workflow is shown below.
-![Home Illustration](img/home_illustration.png)
+  <section class="pynnlf-section pynnlf-solution">
+    <div class="pynnlf-section__intro">
+      <p class="pynnlf-eyebrow">The tool</p>
+      <h2>PyNNLF turns model comparison into a repeatable workflow.</h2>
+      <p>
+        Users define the forecast problem and model specification in a YAML file. PyNNLF prepares the data, creates lag and calendar features, runs cross-validation, and stores the result using a consistent output structure.
+      </p>
+    </div>
+    <div class="pynnlf-workflow">
+      <span>Dataset</span>
+      <span>Forecast horizon</span>
+      <span>Model and hyperparameters</span>
+      <span>Cross-validated outputs</span>
+    </div>
+  </section>
 
-# Input
-1. **Forecast Target**: dataset and forecast horizon defined in `example_project/specs/experiment.yaml`.
-2. **Model Specification**: model and hyperparameters defined in `example_project/specs/experiment.yaml`.
+  <section class="pynnlf-section pynnlf-capability">
+    <p class="pynnlf-eyebrow">What it outputs</p>
+    <h2>Accuracy, stability, runtime, plots, and trained models in one experiment folder.</h2>
+    <div class="pynnlf-capability-grid">
+      <article>
+        <h3>Accuracy</h3>
+        <p>Train and test errors, including RMSE and nRMSE.</p>
+      </article>
+      <article>
+        <h3>Stability</h3>
+        <p>Cross-validation standard deviation to show whether performance is consistent.</p>
+      </article>
+      <article>
+        <h3>Runtime</h3>
+        <p>Training time so accuracy can be weighed against computational cost.</p>
+      </article>
+      <article>
+        <h3>Reproducibility</h3>
+        <p>Fold-level forecasts, residuals, trained models, and recap files.</p>
+      </article>
+    </div>
+  </section>
 
-# Output
-1. `a1_experiment_result.csv` - Contains accuracy (cross-validated test n-RMSE), stability (accuracy stddev), training time, and the run seed.
-2. `a2_hyperparameter.csv` - Lists effective hyperparameters used for each model.
-3. `a3_cross_validation_result.csv` - Detailed results for each cross-validation split.
-4. `E00001_cv1_plots/` - Optional plot folder for the first CV fold when plot generation is enabled.
-5. `cv_test/` and `cv_train/` - Folders containing time series of observation, forecast, and residuals for each cross-validation split.
-6. `experiment_result/a1_experiment_result.csv` - Optional recap across multiple experiments generated by `recap_experiments`.
+  <section class="pynnlf-section pynnlf-install">
+    <div>
+      <p class="pynnlf-eyebrow">Use it</p>
+      <h2>Install PyNNLF with pip and run an experiment from a YAML spec.</h2>
+    </div>
+    <div class="pynnlf-code-pair">
+      <pre><code>python -m pip install pynnlf</code></pre>
+      <pre><code>import pynnlf
 
-To skip plot generation and save storage, pass `plot_enabled=False` to `run_experiment(...)`, `run_experiment_batch(...)`, or `run_tests(...)`.
+pynnlf.init("example_project")
+pynnlf.run_experiment("example_project/specs/experiment.yaml")</code></pre>
+    </div>
+  </section>
 
-# Tool Output Naming Convention
-Format:
-`[experiment_no]_[experiment_date]_[dataset]_[forecast_horizon]_[model]_[hyperparameter]`
-
-Example:
-`E00001_250915_ds0_fh30_m6_lr_hp1`
+  <section class="pynnlf-references" aria-label="References">
+    <p>[1] H. Cao, L. Yang, H. Li, K. Wang, Net Power Prediction for High Permeability Distributed Photovoltaic Integration System, J. Phys. Conf. Ser., 2023. <a href="https://doi.org/10.1088/1742-6596/2418/1/012069">https://doi.org/10.1088/1742-6596/2418/1/012069</a>.</p>
+    <p>[2] J. Hu, W. Hu, D. Cao, X. Sun, J. Chen, Y. Huang, Z. Chen, F. Blaabjerg, Probabilistic net load forecasting based on transformer network and Gaussian process-enabled residual modeling learning method, Renew. Energy 225 (2024). <a href="https://doi.org/10.1016/j.renene.2024.120253">https://doi.org/10.1016/j.renene.2024.120253</a>.</p>
+    <p>[3] M. Sun, T. Zhang, Y. Wang, G. Strbac, C. Kang, Using Bayesian Deep Learning to Capture Uncertainty for Residential Net Load Forecasting, IEEE Transactions on Power Systems 35 (2020) 188-201. <a href="https://doi.org/10.1109/TPWRS.2019.2924294">https://doi.org/10.1109/TPWRS.2019.2924294</a>.</p>
+  </section>
+</section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,13 @@ hide:
     <p class="pynnlf-eyebrow">PyNNLF</p>
     <h1>Reliable net load forecasting evaluation, not just another new model.</h1>
     <p class="pynnlf-hero__lead">
-      PyNNLF is an open-source Python tool for comparing net load forecasting models with public datasets, simple benchmarks, cross-validation, and reproducible experiment outputs.
+      PyNNLF (Python for Network Net Load Forecasting) is an open-source Python tool for comparing net load forecasting models with public datasets, simple benchmarks, cross-validation, and reproducible experiment outputs.
+    </p>
+    <p class="pynnlf-definition">
+      Net load is the underlying electricity load minus renewable energy generation. Net load forecasting means predicting that remaining demand over a future forecast horizon.
     </p>
     <div class="pynnlf-actions">
-      <a class="pynnlf-button pynnlf-button--primary" href="getting_started/">Install PyNNLF</a>
+      <a class="pynnlf-button pynnlf-button--primary pynnlf-button--install" href="getting_started/">Install PyNNLF</a>
       <a class="pynnlf-button" href="examples/">Read the docs</a>
       <a class="pynnlf-button" href="https://github.com/mssamhan31/PyNNLF">GitHub</a>
     </div>
@@ -23,22 +26,23 @@ hide:
       <p class="pynnlf-eyebrow">The research issue</p>
       <h2>Many papers claim superior forecasting accuracy. Fewer make the comparison easy to trust.</h2>
       <p>
-        Since 2016, more than 102 academic papers have been published on net load forecasting. At least 84 introduced a novel method. However, many papers did not use simple benchmark models, relied on private datasets, or did not publicly share implementation code.
+        Since 2016, more than 102 academic papers have been published on net load forecasting. At least 84 introduced a novel model. However, many papers did not use simple benchmark models, relied on private datasets, or did not publicly share implementation code.
       </p>
     </div>
 
     <div class="pynnlf-quote-stack">
+      <p class="pynnlf-quote-lead">Typical excerpts found in net load forecasting papers include:</p>
       <figure>
         <blockquote>&ldquo;&hellip; and it is concluded that the proposed method has higher prediction accuracy and better prediction effect &hellip;&rdquo;</blockquote>
-        <figcaption>[1] Cao et al., 2023</figcaption>
+        <figcaption><a href="https://doi.org/10.1088/1742-6596/2418/1/012069">[1] Cao et al., 2023</a></figcaption>
       </figure>
       <figure>
         <blockquote>&ldquo;Comparative tests utilizing real-world data verify the superiority of the proposed method over other state-of-the-art net load forecasting algorithms.&rdquo;</blockquote>
-        <figcaption>[2] Hu et al., 2024</figcaption>
+        <figcaption><a href="https://doi.org/10.1016/j.renene.2024.120253">[2] Hu et al., 2024</a></figcaption>
       </figure>
       <figure>
         <blockquote>&ldquo;More-over, the performance of the BDLSTM model also dominates when compared with the best of the state-of-the-art methods, &hellip;&rdquo;</blockquote>
-        <figcaption>[3] Sun et al., 2020</figcaption>
+        <figcaption><a href="https://doi.org/10.1109/TPWRS.2019.2924294">[3] Sun et al., 2020</a></figcaption>
       </figure>
     </div>
   </section>
@@ -51,7 +55,7 @@ hide:
       </div>
       <div>
         <strong>84</strong>
-        <span>introduced a novel method</span>
+        <span>introduced a novel model</span>
       </div>
       <div>
         <strong>75%</strong>
@@ -125,5 +129,9 @@ pynnlf.run_experiment("example_project/specs/experiment.yaml")</code></pre>
     <p>[1] H. Cao, L. Yang, H. Li, K. Wang, Net Power Prediction for High Permeability Distributed Photovoltaic Integration System, J. Phys. Conf. Ser., 2023. <a href="https://doi.org/10.1088/1742-6596/2418/1/012069">https://doi.org/10.1088/1742-6596/2418/1/012069</a>.</p>
     <p>[2] J. Hu, W. Hu, D. Cao, X. Sun, J. Chen, Y. Huang, Z. Chen, F. Blaabjerg, Probabilistic net load forecasting based on transformer network and Gaussian process-enabled residual modeling learning method, Renew. Energy 225 (2024). <a href="https://doi.org/10.1016/j.renene.2024.120253">https://doi.org/10.1016/j.renene.2024.120253</a>.</p>
     <p>[3] M. Sun, T. Zhang, Y. Wang, G. Strbac, C. Kang, Using Bayesian Deep Learning to Capture Uncertainty for Residential Net Load Forecasting, IEEE Transactions on Power Systems 35 (2020) 188-201. <a href="https://doi.org/10.1109/TPWRS.2019.2924294">https://doi.org/10.1109/TPWRS.2019.2924294</a>.</p>
+  </section>
+
+  <section class="pynnlf-disclosure" aria-label="Disclosure">
+    <p>Disclosure: PyNNLF is an open-source tool developed as part of Samhan's PhD study, which is funded by UNSW Sydney, Ausgrid, RACE for 2030, and the NSW Decarbonisation Innovation Hub.</p>
   </section>
 </section>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,14 @@
-site_name: PyNNLF Documentation
+site_name: PyNNLF
 site_url: https://mssamhan31.github.io/PyNNLF/
 
 theme:
   name: material
   features:
+    - navigation.sections
+    - navigation.top
     - content.code.copy
+extra_css:
+  - assets/css/website.css
 plugins:
   - search
   - mkdocstrings:
@@ -12,12 +16,12 @@ plugins:
         python:
           options:
             show_source: true
-nav: 
+nav:
   - Home: index.md
-  - Getting Started: getting_started.md
-  - Examples: examples.md
-  - Tool Testing: tool_testing.md
-  - Detailed Guide:
+  - Docs:
+      - Getting Started: getting_started.md
+      - Examples: examples.md
+      - Tool Testing: tool_testing.md
       - Datasets & Models: datasets_models.md
       - How to run an experiment: run_experiment.md
       - How to modify model hyperparameter: modify_hyper.md
@@ -25,10 +29,10 @@ nav:
       - How to add a dataset: add_dataset.md
       - Repo structure: repo_structure.md
       - API Reference: api_reference.md
-  - Features & Limitations: features_limitations.md
-  - Acknowledgement & License: ack_license.md
-  - Support & Contributing: support_contributing.md
-  - Contributors: contributors.md
+      - Features & Limitations: features_limitations.md
+      - Acknowledgement & License: ack_license.md
+      - Support & Contributing: support_contributing.md
+      - Contributors: contributors.md
 markdown_extensions:
   - pymdownx.superfences
   - toc:


### PR DESCRIPTION
## Summary
- Adds a cleaner one-page PyNNLF website landing page.
- Focuses the homepage on the reproducibility problem in net load forecasting research.
- Preserves technical documentation under a simplified Docs navigation.

## Website content
- Spells out PyNNLF as Python for Network Net Load Forecasting.
- Defines net load forecasting in plain language.
- Adds three linked paper excerpts showing common model-superiority claims.
- Adds literature-review facts on benchmark use, public datasets, and code sharing.
- Adds funding/disclosure text for the PhD project.

## Validation
- Ran `mkdocs build --strict` successfully.
- Served locally at `http://127.0.0.1:8000/PyNNLF/` and verified the homepage loads.
- Confirmed technical docs remain accessible under Docs.

## Deployment note
- This PR targets `main`; GitHub Pages deploy is expected to run only after merge to `main`.